### PR TITLE
package.mk: Use `rabbitmq-gen-smtp` as the dependency name

### DIFF
--- a/package.mk
+++ b/package.mk
@@ -1,3 +1,3 @@
 RELEASABLE:=true
 RETAIN_ORIGINAL_VERSION:=true
-DEPS:=rabbitmq-server rabbitmq-erlang-client gen_smtp
+DEPS:=rabbitmq-server rabbitmq-erlang-client rabbitmq-gen-smtp


### PR DESCRIPTION
... not `gen_smtp` as this is not the name of the repository.

This avoids a rename of the checkout and pleases `release-build/build-community-plugins.py` from the RabbitMQ Umbrella project.
