### PR TITLE
Set user as anonymous in EHLO when auth disable

### DIFF
--- a/src/rabbit_email_handler.erl
+++ b/src/rabbit_email_handler.erl
@@ -41,7 +41,7 @@ handle_HELO(Hostname, State) ->
     rabbit_log:info("HELO from ~s~n", [Hostname]),
     case application:get_env(rabbitmq_email, server_auth) of
         {ok, false} ->
-            {ok, 655360, State#state{auth_user=anonymous}}; % 640kb should be enough for anyone
+            {ok, 655360, set_user_as_anonymous(State)}; % 640kb should be enough for anyone
         _Else ->
             % we expect EHLO will come
             {ok, State} % use the default 10mb limit

--- a/src/rabbit_email_handler.erl
+++ b/src/rabbit_email_handler.erl
@@ -49,13 +49,16 @@ handle_HELO(Hostname, State) ->
 
 handle_EHLO(Hostname, Extensions, State) ->
     rabbit_log:info("EHLO from ~s~n", [Hostname]),
-    {ok, auth_extensions(starttls_extension(Extensions)), State}.
-
-auth_extensions(Extensions) ->
+    ExtensionsTLS = starttls_extension(Extensions),
     case application:get_env(rabbitmq_email, server_auth) of
-        {ok, false} -> Extensions;
-        {ok, rabbitmq} -> [{"AUTH", "PLAIN LOGIN"} | Extensions]
+        {ok, false} ->
+            {ok, ExtensionsTLS, set_user_as_anonymous(State)};
+        {ok, rabbitmq} ->
+            {ok, [{"AUTH", "PLAIN LOGIN"} | ExtensionsTLS], State}
     end.
+
+set_user_as_anonymous(State) ->
+    State#state{auth_user=anonymous}.
 
 starttls_extension(Extensions) ->
     case application:get_env(rabbitmq_email, server_starttls) of


### PR DESCRIPTION
hi, Gotthardp:

  I found when server_auth is false, EHLO handler should update the auth_user in state as anonymous, otherwise the handle_DATA handler would also return `auth_required`.
