### PR TITLE
Introduce config option for setting concurrent sessions limit

### DIFF
--- a/src/rabbitmq_email.app.src
+++ b/src/rabbitmq_email.app.src
@@ -20,6 +20,7 @@
         ]},
         {server_auth, rabbitmq},
         {server_starttls, false},
+        {session_limit, 20},
         {email_domains,
             [{<<"example.com">>, {<<"/">>, <<"email-in">>}}
         ]},


### PR DESCRIPTION
Hi!

We use this plugin to handle email bounces and unsubscribe requests and have encountered a problem wtih too restrictive session limit. As a quick hack we tested 20000 in our fork and it seemed to work fine under production load. 

I tried to move this parameter to config file so you would accept it to upstream (and it looks like something that would work), but Erlang is a bit too much for me to grasp at once and travis-ci somehow fails to build even clean master from my account, so I would welcome any directions you can provide for me to ensure this fix would behave as expected. 